### PR TITLE
Add PWA SVG icon and help/guide page

### DIFF
--- a/app/help/page.js
+++ b/app/help/page.js
@@ -1,0 +1,224 @@
+"use client";
+
+import Link from "next/link";
+
+const F_OUT = "var(--font-outfit, 'Outfit', sans-serif)";
+const F_SER = "var(--font-dm-serif, 'DM Serif Display', serif)";
+
+export default function HelpPage() {
+  return (
+    <div
+      style={{
+        maxWidth: 430,
+        margin: "0 auto",
+        padding: "0 16px",
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: F_SER,
+        position: "relative",
+        overflowY: "auto",
+      }}
+    >
+      {/* Header */}
+      <div style={{ paddingTop: 16, paddingBottom: 16, flexShrink: 0 }}>
+        <div
+          style={{
+            fontSize: 26,
+            fontWeight: 400,
+            letterSpacing: "-1px",
+            color: "#fff",
+            lineHeight: 1,
+            fontStyle: "italic",
+          }}
+        >
+          Anagram Chain
+        </div>
+        <div
+          style={{
+            fontFamily: F_OUT,
+            fontSize: 9,
+            color: "#33334a",
+            letterSpacing: 3,
+            marginTop: 3,
+          }}
+        >
+          GUIDE
+        </div>
+      </div>
+
+      {/* How to Play */}
+      <Section title="How to Play">
+        <Step icon={"\uD83D\uDD24"} color="#0ea5e9">
+          Each day, you get a chain of <strong style={{ color: "#0ea5e9" }}>5 scrambled words</strong> to
+          unscramble. Solve one word to unlock the next.
+        </Step>
+        <Step icon={"\u2B06\uFE0F"} color="#22c55e">
+          Words get progressively longer: start with <strong style={{ color: "#22c55e" }}>4 letters</strong>,
+          then 5, then 6. The challenge grows as you go.
+        </Step>
+        <Step icon={"\uD83D\uDC46"} color="#e8e8f0">
+          <strong style={{ color: "#e8e8f0" }}>Tap</strong> the scrambled letter tiles to place them into
+          the answer slots. Tap a placed letter to remove it. You can also type on a keyboard.
+        </Step>
+        <Step icon={"\u23F1\uFE0F"} color="#ffd166">
+          A <strong style={{ color: "#ffd166" }}>timer</strong> runs for the entire chain. Your total time
+          is your score — the faster, the better!
+        </Step>
+        <Step icon={"\uD83D\uDCA1"} color="#a78bfa">
+          Stuck? Use a <strong style={{ color: "#a78bfa" }}>hint</strong> to reveal one correct letter.
+          Each hint adds a 15-second penalty to your time.
+        </Step>
+        <Step icon={"\u2B50"} color="#fbbf24">
+          Find valid <strong style={{ color: "#fbbf24" }}>bonus words</strong> — real anagrams of the target
+          word that are different from the answer. They count toward your score!
+        </Step>
+      </Section>
+
+      {/* Tips */}
+      <Section title="Tips">
+        <Tip>Look for common letter patterns like -ING, -TION, -ED, TH-, and SH- to spot word structure quickly.</Tip>
+        <Tip>Try vowels first. Placing vowels often reveals the word shape faster than consonants.</Tip>
+        <Tip>Use the <strong style={{ color: "#555577" }}>Shuffle</strong> button to rearrange remaining letters — a fresh arrangement can spark recognition.</Tip>
+        <Tip>Save your hint for the longer 6-letter words where there are more possible combinations.</Tip>
+        <Tip>If your guess is a real word but not the answer, it might count as a bonus word!</Tip>
+      </Section>
+
+      {/* About */}
+      <Section title="About">
+        <p
+          style={{
+            fontFamily: F_OUT,
+            fontSize: 13,
+            color: "#555577",
+            lineHeight: 1.7,
+          }}
+        >
+          Anagram Chain is a free daily word puzzle. A new chain is available every day at midnight.
+          Your stats, streaks, and completion history are saved locally on your device.
+        </p>
+        <p
+          style={{
+            fontFamily: F_OUT,
+            fontSize: 13,
+            color: "#555577",
+            lineHeight: 1.7,
+            marginTop: 8,
+          }}
+        >
+          Install it as an app from your browser menu for the best experience — it works offline too.
+        </p>
+      </Section>
+
+      {/* Back button */}
+      <div style={{ padding: "24px 0 32px", flexShrink: 0 }}>
+        <Link
+          href="/"
+          style={{
+            display: "block",
+            width: "100%",
+            padding: "14px",
+            background: "linear-gradient(135deg, #0c4a6e, #0ea5e9)",
+            border: "none",
+            borderRadius: 14,
+            color: "#fff",
+            fontFamily: F_OUT,
+            fontWeight: 700,
+            fontSize: 13,
+            letterSpacing: 2,
+            cursor: "pointer",
+            boxShadow: "0 6px 24px #0ea5e955",
+            textAlign: "center",
+            textDecoration: "none",
+          }}
+        >
+          {"\u2190"} BACK TO GAME
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/* ── Reusable sub-components ── */
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: 20, flexShrink: 0 }}>
+      <div
+        style={{
+          fontFamily: "var(--font-outfit, 'Outfit', sans-serif)",
+          fontWeight: 700,
+          fontSize: 11,
+          letterSpacing: 3,
+          color: "#0ea5e9",
+          marginBottom: 12,
+          textTransform: "uppercase",
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          background: "#0d0d1e",
+          border: "1px solid #1c1c35",
+          borderRadius: 14,
+          padding: "14px 16px",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Step({ icon, color, children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+        marginBottom: 12,
+      }}
+    >
+      <span style={{ color, fontSize: 16, lineHeight: 1, flexShrink: 0, marginTop: 1 }}>
+        {icon}
+      </span>
+      <span
+        style={{
+          fontFamily: "var(--font-outfit, 'Outfit', sans-serif)",
+          fontSize: 13,
+          color: "#888898",
+          lineHeight: 1.6,
+        }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function Tip({ children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+        marginBottom: 10,
+      }}
+    >
+      <span style={{ color: "#22c55e", fontSize: 8, lineHeight: 2.2, flexShrink: 0 }}>{"\u25CF"}</span>
+      <span
+        style={{
+          fontFamily: "var(--font-outfit, 'Outfit', sans-serif)",
+          fontSize: 13,
+          color: "#888898",
+          lineHeight: 1.6,
+        }}
+      >
+        {children}
+      </span>
+    </div>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -18,6 +18,7 @@ export const metadata = {
   title: "Anagram Chain — Daily Word Puzzle",
   description: "Unscramble 5 words in a chain. Solve one to unlock the next. New chain every day.",
   manifest: "/manifest.json",
+  icons: { icon: "/icon.svg", apple: "/icon.svg" },
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",

--- a/components/AnagramGame.jsx
+++ b/components/AnagramGame.jsx
@@ -5,6 +5,7 @@
 // ============================================================
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
 import CHAINS from "../data/chains";
 import { getDailyChain, getDailySeed, scrambleWord } from "../lib/daily";
 import { playTap, playPlace, playCorrect, playWrong, playComplete, playHint, playBonus } from "../lib/sounds";
@@ -557,6 +558,29 @@ export default function AnagramGame() {
           </div>
         </div>
         <div style={{ display: "flex", gap: 14, alignItems: "center", paddingTop: 2 }}>
+          <Link
+            href="/help"
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 8,
+              border: "1.5px solid #1c1c35",
+              background: "#0d0d1e",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontFamily: F_OUT,
+              fontWeight: 700,
+              fontSize: 13,
+              color: "#33334a",
+              textDecoration: "none",
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+            aria-label="Help"
+          >
+            ?
+          </Link>
           <div style={{ textAlign: "center" }}>
             <div
               style={{

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a1a"/>
+      <stop offset="100%" stop-color="#0d1a2e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c4a6e"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="512" height="512" rx="108" fill="url(#bg)"/>
+
+  <!-- Subtle ambient glow -->
+  <circle cx="256" cy="200" r="180" fill="url(#glow)"/>
+
+  <!-- Chain link 1 (top-left) -->
+  <rect x="88" y="120" width="72" height="80" rx="14" fill="#0d1a2e" stroke="#1e3a5f" stroke-width="3"/>
+  <text x="124" y="174" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="38" fill="#e8e8f0">A</text>
+
+  <!-- Chain link 2 (top-right) -->
+  <rect x="180" y="120" width="72" height="80" rx="14" fill="#0d1a2e" stroke="#1e3a5f" stroke-width="3"/>
+  <text x="216" y="174" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="38" fill="#e8e8f0">N</text>
+
+  <!-- Chain link connector (top) -->
+  <rect x="268" y="120" width="72" height="80" rx="14" fill="#0d1a2e" stroke="#0ea5e9" stroke-width="3" stroke-opacity="0.5"/>
+  <text x="304" y="174" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="38" fill="#0ea5e9">A</text>
+
+  <!-- Chain link 4 (top-far-right) -->
+  <rect x="356" y="120" width="72" height="80" rx="14" fill="#0d1a2e" stroke="#1e3a5f" stroke-width="3"/>
+  <text x="392" y="174" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="38" fill="#e8e8f0">G</text>
+
+  <!-- Connecting chain visual (curved line between rows) -->
+  <path d="M256 210 C256 250, 256 250, 256 290" stroke="#0ea5e9" stroke-width="3" fill="none" stroke-dasharray="8,6" opacity="0.4"/>
+  <circle cx="256" cy="250" r="6" fill="#0ea5e9" opacity="0.6"/>
+
+  <!-- Bottom row — answer slots -->
+  <rect x="100" y="300" width="64" height="72" rx="12" fill="#0ea5e90d" stroke="#0ea5e933" stroke-width="2.5"/>
+  <text x="132" y="348" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="32" fill="#0ea5e9">G</text>
+
+  <rect x="178" y="300" width="64" height="72" rx="12" fill="#0ea5e90d" stroke="#0ea5e933" stroke-width="2.5"/>
+  <text x="210" y="348" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="32" fill="#0ea5e9">A</text>
+
+  <rect x="256" y="300" width="64" height="72" rx="12" fill="#0ea5e90d" stroke="#0ea5e933" stroke-width="2.5"/>
+  <text x="288" y="348" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="32" fill="#0ea5e9">N</text>
+
+  <rect x="334" y="300" width="64" height="72" rx="12" fill="#0ea5e90d" stroke="#0ea5e933" stroke-width="2.5"/>
+  <text x="366" y="348" text-anchor="middle" font-family="sans-serif" font-weight="700" font-size="32" fill="#0ea5e9">A</text>
+
+  <!-- Progress dots at bottom -->
+  <circle cx="196" cy="416" r="8" fill="#22c55e" opacity="0.9"/>
+  <circle cx="226" cy="416" r="8" fill="#22c55e" opacity="0.9"/>
+  <circle cx="256" cy="416" r="8" stroke="#0ea5e9" stroke-width="2.5" fill="none" opacity="0.8"/>
+  <circle cx="286" cy="416" r="8" stroke="#1e3a5f" stroke-width="2.5" fill="none" opacity="0.5"/>
+  <circle cx="316" cy="416" r="8" stroke="#1e3a5f" stroke-width="2.5" fill="none" opacity="0.5"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,8 @@
   "theme_color": "#0ea5e9",
   "orientation": "portrait",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" },
+    { "src": "/icon.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any maskable" },
+    { "src": "/icon.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any maskable" }
   ]
 }


### PR DESCRIPTION
## Summary
- **G-02 PWA Icons**: Replace broken 1x1 PNG icon stubs with a polished SVG icon featuring scrambled/solved letter tiles, a chain connector, and progress dots — all in the game's color scheme. Updated `manifest.json` with `"purpose": "any maskable"` and added `icons` metadata to `layout.js` for apple-touch-icon support.
- **G-03 Help Page**: Created `/help` route with How to Play, Tips, and About sections styled to match the game's dark theme. Added a `?` button in the game header for quick access.

## Test plan
- [ ] Verify the SVG icon renders correctly as a favicon and in the PWA install prompt
- [ ] Confirm apple-touch-icon works on iOS Safari (Add to Home Screen)
- [ ] Navigate to /help and verify all sections display correctly
- [ ] Click the "?" button in the game header to confirm it links to /help
- [ ] Click "Back to Game" on the help page to return to the main game
- [ ] Run `npm run build` — passes cleanly

Closes MattAtencio/anagram-chain#8
Closes MattAtencio/anagram-chain#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)